### PR TITLE
Percent-encoding bugfix

### DIFF
--- a/lib/wax-scripts/ext/string.lua
+++ b/lib/wax-scripts/ext/string.lua
@@ -34,7 +34,7 @@ function string.camelCase(s)
 end
 
 function string.escape(s)
-  s = string.gsub(s, "([!%*'%(%);:@&=%+%$,/%?#%[%]<>~%.\"{}|\\%-`_%^%%])",
+  s = string.gsub(s, "([!%*'%(%);:@&=%+%$,/%?#%[%]<>~%.\"{}|\\%-`_%^%%%c])",
                   function (c)
                     return string.format("%%%02X", string.byte(c))
                   end)


### PR DESCRIPTION
Both reserved and unsafe characters should be escaped. See http://en.wikipedia.org/wiki/Percent-encoding and http://www.blooberry.com/indexdot/html/topics/urlencoding.htm for reference. 

Cheers
