### PR TITLE
FIX: README.md Tutorials Links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 *.pbxuser
 *.perspectivev3
 wax.framework
+*~

--- a/README.md
+++ b/README.md
@@ -108,11 +108,11 @@ Since Wax converts NSString, NSArray, NSDictionary and NSNumber to native Lua va
 Tutorials
 ---------
 
-[Setting up iPhone wax](http://probablyinteractive.com/2009/10/18/Setting-up-iPhone-Wax.html)
+[Setting up iPhone wax](https://github.com/probablycorey/wax/wiki/Installation)
 
-[How does iPhone Wax work?](http://probablyinteractive.com/2009/10/19/How-does-iPhone-Wax-work.html)
+[How does iPhone Wax work?](https://github.com/probablycorey/wax/wiki/Overview)
 
-[Twitter client in Wax](http://probablyinteractive.com/2009/10/20/Wax-talks-to-twitter.html)
+[Twitter client in Wax](https://github.com/probablycorey/wax/wiki/Twitter-example)
 
 Which API's are included?
 -------------------------


### PR DESCRIPTION
Hello,

I' new to wax, I found some tutorials links in README.md is unavailable and redirect to github wiki, so I modified README.md.

Please check it, thanks a lot.
