### PR TITLE
Strip fix

### DIFF
--- a/lib/stdlib/ext/string.lua
+++ b/lib/stdlib/ext/string.lua
@@ -17,7 +17,7 @@ function string.split(s, sep)
 end
 
 function string.strip(s, pattern)
-  pattern = pattern or "%s"
+  pattern = pattern or "%s+"
   s = s:gsub("^" .. pattern, "")
   s = s:gsub(pattern .. "$", "")
   return s


### PR DESCRIPTION
I believe this was the intended behavior for string.strip() ...
