### PR TITLE
Base64 decode nul fix

### DIFF
--- a/lib/stdlib/helpers/base64.lua
+++ b/lib/stdlib/helpers/base64.lua
@@ -52,7 +52,9 @@ function decode(data)
   local result=""
   for dpos=0,string.len(data)-1,4 do
     for char=1,4 do chars[char] = base64bytes[(string.sub(data,(dpos+char),(dpos+char)) or "=")] end
-    result = string.format('%s%s%s%s',result,string.char(lor(lsh(chars[1],2), rsh(chars[2],4))),(chars[3] ~= nil) and string.char(lor(lsh(chars[2],4), rsh(chars[3],2))) or "",(chars[4] ~= nil) and string.char(lor(lsh(chars[3],6) % 192, (chars[4]))) or "")
+    result = result .. string.char(lor(lsh(chars[1],2), rsh(chars[2],4)))
+    result = result .. ((chars[3] ~= nil) and string.char(lor(lsh(chars[2],4), rsh(chars[3],2))) or "")
+    result = result .. ((chars[4] ~= nil) and string.char(lor(lsh(chars[3],6) % 192, (chars[4]))) or "")
   end
   return result
 end

--- a/tools/Tests/scripts/tests/base64Test.lua
+++ b/tools/Tests/scripts/tests/base64Test.lua
@@ -1,0 +1,11 @@
+
+describe["Base64 decoding"] = function()
+
+  it["should pass ASCII NULs"] = function()
+    local ans = wax.base64.decode("AAA=")
+    expect(#ans).should_be(2)
+    expect(string.byte(ans, 1)).should_be(0)
+    expect(string.byte(ans, 2)).should_be(0)
+  end
+
+end

--- a/tools/Tests/scripts/tests/init.lua
+++ b/tools/Tests/scripts/tests/init.lua
@@ -8,6 +8,7 @@ require "tests.structTest"
 require "tests.gcTest"
 require "tests.jsonTest"
 require "tests.xmlTest"
+require "tests.base64Test"
 
 puts("\nResults\n-------")
 spec:report()


### PR DESCRIPTION
wax.base64.decode() would not pass decoded NUL characters because string.format() eats them for %s.
