### PR TITLE
Ability to pick views by touching while being connected to WaxServer.

### DIFF
--- a/lib/stdlib/helpers/init.lua
+++ b/lib/stdlib/helpers/init.lua
@@ -6,6 +6,7 @@ require "wax.helpers.time"
 require "wax.helpers.cache"
 require "wax.helpers.autoload"
 require "wax.helpers.WaxServer"
+require "wax.helpers.pickView"
 
 -- Just a bunch of global helper functions
 

--- a/lib/stdlib/helpers/pickView.lua
+++ b/lib/stdlib/helpers/pickView.lua
@@ -1,0 +1,54 @@
+
+function startPick()
+    local w = UIApplication:sharedApplication():keyWindow()
+    _interceptor = InterceptorView:alloc():initWithFrame(w:bounds())
+    w:addSubview(_interceptor)
+    return "Go on, touch something. Get the view by calling endPick() when you're done."
+end
+
+function endPick()
+    local v = _interceptor:pickedView()
+    _interceptor:removeFromSuperview()
+    return v
+end
+
+-- wax doesn't automagically bridge C functions
+function CGRectContainsPoint(rect, point)
+    return rect.x <= point.x
+       and point.x <= rect.x + rect.width
+       and rect.y <= point.y
+       and point.y <= rect.y + rect.height
+end
+
+waxClass{"InterceptorView", UIView}
+
+function touchesEnded_withEvent(self, touches, event)
+    local point = touches:anyObject():locationInView(self)
+    local w = UIApplication:sharedApplication():keyWindow()
+    local pointInWindow = w:convertPoint_fromView(point, self)
+    self.pickedView_ = self:findOwnerOfPoint_startingWith(pointInWindow, w)
+    print(self.pickedView_:class())
+end
+
+function pickedView(self)
+    return self.pickedView_
+end
+
+function findOwnerOfPoint_startingWith(self, point, view)
+    if view == self then
+        return nil
+    end
+
+    if not CGRectContainsPoint(view:bounds(), point) then
+        return nil
+    end
+
+    local betterResult = nil
+
+    for i, subview in ipairs(view:subviews()) do
+        pointInSubview = subview:convertPoint_fromView(point, view)
+        betterResult = self:findOwnerOfPoint_startingWith(pointInSubview, subview) or betterResult
+    end
+
+    return betterResult or view
+end


### PR DESCRIPTION
Telnet session looks like this:

```
 % rlwrap telnet localhost 9000
Trying ::1...
telnet: connect to address ::1: Connection refused
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
> startPick()
Go on, touch something. Get the view by calling endPick() when you're done.
> (0x9636734 => 0x117bec0) _UINavigationBarBackground
v = endPick()
nil
> v
(0x9638ff4 => 0x96ba170) <_UINavigationBarBackground: 0x96ba170; frame = (0 0; 320 44); opaque = NO; autoresize = W; userInteractionEnabled = NO; layer = <CALayer: 0x96ba840>>
> v:setBackgroundColor(UIColor:greenColor())
(0x9645194 => 0x9645140) UIDeviceRGBColorSpace 0 1 0 1
>
```
